### PR TITLE
Fix undefined variable $ratingId

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Model/Resource/Engine/Index.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Resource/Engine/Index.php
@@ -84,9 +84,8 @@ class Smile_ElasticSearch_Model_Resource_Engine_Index extends Mage_CatalogSearch
      */
     protected function _getDefaultRatingId($storeId)
     {
-        if (!Mage::helper('core')->isModuleEnabled('Mage_Rating')) {
-            $ratingId = false;
-        } else if (!isset($this->_defaultRatingIdByStore[$storeId])) {
+        $ratingId = false;
+        if (Mage::helper('core')->isModuleEnabled('Mage_Rating') && !isset($this->_defaultRatingIdByStore[$storeId])) {
             $ratingId = false;
             $ratings = Mage::getResourceModel('rating/rating_collection')
                 ->setStoreFilter($storeId);

--- a/src/app/code/community/Smile/ElasticSearch/Model/Resource/Engine/Index.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Resource/Engine/Index.php
@@ -84,18 +84,20 @@ class Smile_ElasticSearch_Model_Resource_Engine_Index extends Mage_CatalogSearch
      */
     protected function _getDefaultRatingId($storeId)
     {
-        $ratingId = false;
-        if (Mage::helper('core')->isModuleEnabled('Mage_Rating') && !isset($this->_defaultRatingIdByStore[$storeId])) {
-            $ratingId = false;
-            $ratings = Mage::getResourceModel('rating/rating_collection')
-                ->setStoreFilter($storeId);
+        if (!isset($this->_defaultRatingIdByStore[$storeId])) {
+            if (!Mage::helper('core')->isModuleEnabled('Mage_Rating')) {
+                $ratingId = false;
+            } else {
+                $ratingId = false;
+                $ratings = Mage::getResourceModel('rating/rating_collection')
+                    ->setStoreFilter($storeId);
 
-            if ($ratings->getSize() > 0) {
-                $ratingId = $ratings->getFirstItem()->getId();
+                if ($ratings->getSize() > 0) {
+                    $ratingId = $ratings->getFirstItem()->getId();
+                }
             }
+            $this->_defaultRatingIdByStore[$storeId] = $ratingId;
         }
-
-        $this->_defaultRatingIdByStore[$storeId] = $ratingId;
 
         return $this->_defaultRatingIdByStore[$storeId];
     }


### PR DESCRIPTION
$ratingId is not defined in the following scenario: 
If the rating module is enabled and the ratingId was already set for the store

You can test/reproduce this by saving a product in the backend.