### PR TITLE
Fix category filter on category pages

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Model/Catalog/Layer/Filter/Category.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Catalog/Layer/Filter/Category.php
@@ -117,6 +117,25 @@ class Smile_ElasticSearch_Model_Catalog_Layer_Filter_Category extends Mage_Catal
     }
 
     /**
+     * @inheritdoc
+     *
+     * Additional validation when on a category page, so the sub category of the store root category is not added as filter.
+     *
+     * @param Mage_Catalog_Model_Category $category
+     * @return bool
+     */
+    protected function _isValidCategory($category)
+    {
+        $rootId = (int) Mage::app()->getStore()->getRootCategoryId();
+        $isCategoryPage = Mage::registry('current_category') instanceof Mage_Catalog_Model_Category;
+        if ($isCategoryPage && $category->getParentId() === $rootId) {
+            return false;
+        }
+
+        return parent::_isValidCategory($category);
+    }
+
+    /**
      * Retrieves current items data.
      *
      * @return array


### PR DESCRIPTION
When on a "main" category page (subcategory of the root category) the category was already added as an applied filter.
Clicking on the remove filter button would lead to a 404 page, because you can't view the root category