### PR TITLE
Fixed problem with category product position reindex

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Model/Observer.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Observer.php
@@ -110,14 +110,13 @@ class Smile_ElasticSearch_Model_Observer
     public function reindexCategoryAfterSave(Varien_Event_Observer $observer)
     {
         $helper = Mage::helper('smile_elasticsearch');
-        $category = $observer->getEvent()->getCategory();
+        $category = Mage::registry('category');
         if ($helper->isEnterpriseSupportEnabled() == false) {
             $productIds = $category->getProductCollection()->getAllIds();
             $this->_getIndexer()->resetSearchResults();
             $currentIndex = Mage::helper('catalogsearch')->getEngine()->getCurrentIndex();
             $currentIndex->getMapping('product')->rebuildIndex(null, $productIds);
         } else {
-            $category = $observer->getEvent()->getCategory();
             $productIds = $category->getAffectedProductIds();
             if (empty($productIds)) {
                 return $this;

--- a/src/app/code/community/Smile/ElasticSearch/etc/config.xml
+++ b/src/app/code/community/Smile/ElasticSearch/etc/config.xml
@@ -79,14 +79,14 @@
                     </smile_elasticsearch>
                 </observers>
             </catalog_entity_attribute_save_after>
-            <catalog_category_save_commit_after>
+            <end_process_event_catalog_category_save>
                 <observers>
                     <smile_elasticsearch>
                         <class>smile_elasticsearch/observer</class>
                         <method>reindexCategoryAfterSave</method>
                     </smile_elasticsearch>
                 </observers>
-            </catalog_category_save_commit_after>
+            </end_process_event_catalog_category_save>
             <catalog_category_delete_commit_after>
                 <observers>
                     <smile_elasticsearch>


### PR DESCRIPTION
We have found an issue with saving category product position reindex process.
You use **end_process_event_catalog_category_save** event for *reindexCategoryAfterSave* method.
But at that moment, the position has the old value. It gets new value only after native Magento reindex (it updates _catalog_category_product_index_ table).
So, to fix this you need to use **end_process_event_catalog_category_save** event.