### PR TITLE
Adding a flag to disable module for layered category rendering

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Helper/Data.php
+++ b/src/app/code/community/Smile/ElasticSearch/Helper/Data.php
@@ -126,6 +126,12 @@ class Smile_ElasticSearch_Helper_Data extends Mage_Core_Helper_Abstract
     public function isActiveEngine()
     {
         $engine = $this->getSearchConfigData('engine');
+        if($this->getSearchConfigData('elasticsearch_replace_layered_categories')==0){
+            $current_category = Mage::registry('current_category');
+            if($current_category) {
+                return false;
+            }
+        }
         if ($engine && Mage::getConfig()->getResourceModelClassName($engine)) {
             $model = Mage::getResourceSingleton($engine);
             return $model

--- a/src/app/code/community/Smile/ElasticSearch/Model/Resource/Catalog/Category/Suggest/Collection.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Resource/Catalog/Category/Suggest/Collection.php
@@ -99,6 +99,11 @@ class Smile_ElasticSearch_Model_Resource_Catalog_Category_Suggest_Collection
      */
     public function getSize()
     {
+        $helper = Mage::helper('smile_elasticsearch');
+        if (!$helper->isActiveEngine()) {
+            return parent::getSize();
+        }
+
         if (is_null($this->_totalRecords)) {
             $this->_beforeLoad();
         }
@@ -164,6 +169,11 @@ class Smile_ElasticSearch_Model_Resource_Catalog_Category_Suggest_Collection
      */
     protected function _beforeLoad()
     {
+        $helper = Mage::helper('smile_elasticsearch');
+        if (!$helper->isActiveEngine()) {
+            return parent::_beforeLoad();
+        }
+
         $this->_prepareQuery();
 
         $ids = array();

--- a/src/app/code/community/Smile/ElasticSearch/Model/Resource/Catalog/Product/Collection.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Resource/Catalog/Product/Collection.php
@@ -137,6 +137,10 @@ class Smile_ElasticSearch_Model_Resource_Catalog_Product_Collection extends Mage
      */
     public function getSize()
     {
+        $helper = Mage::helper('smile_elasticsearch');
+        if (!$helper->isActiveEngine()) {
+            return parent::getSize();
+        }
         if (is_null($this->_totalRecords)) {
             $query = clone $this->getSearchEngineQuery();
 
@@ -218,6 +222,10 @@ class Smile_ElasticSearch_Model_Resource_Catalog_Product_Collection extends Mage
      */
     protected function _beforeLoad()
     {
+        $helper = Mage::helper('smile_elasticsearch');
+        if (!$helper->isActiveEngine()) {
+            return parent::_beforeLoad();
+        }
         $this->_prepareQuery();
 
         $ids = array();

--- a/src/app/code/community/Smile/ElasticSearch/etc/config.xml
+++ b/src/app/code/community/Smile/ElasticSearch/etc/config.xml
@@ -270,6 +270,7 @@
         <catalog>
             <search>
                 <elasticsearch_enable_debug_mode>0</elasticsearch_enable_debug_mode>
+                <elasticsearch_replace_layered_categories>1</elasticsearch_replace_layered_categories>
                 <elasticsearch_servers>127.0.0.1:9200</elasticsearch_servers>
                 <elasticsearch_timeout>30</elasticsearch_timeout>
                 <elasticsearch_alias>magento</elasticsearch_alias>

--- a/src/app/code/community/Smile/ElasticSearch/etc/system.xml
+++ b/src/app/code/community/Smile/ElasticSearch/etc/system.xml
@@ -34,6 +34,17 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </engine>
+                        <elasticsearch_replace_layered_categories translate="label comment" module="smile_elasticsearch">
+                            <label>Use Elastic for Layered Category rendering</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <comment>If set yo yes, it will use the module for all layered categories</comment>
+                            <sort_order>49</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><engine>smile_elasticsearch/engine_elasticsearch</engine></depends>
+                        </elasticsearch_replace_layered_categories>
                         <elasticsearch_enable_debug_mode translate="label comment" module="smile_elasticsearch">
                             <label>Enable Debug Mode</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
I had some issues with filters in category layered navigation that are probably caused by an interaction with other modules for Advanced Layered Navigation. I'll have a deeper look in next days. Meanwhile I added a flag in administration to maintain the module active for search but not for straight layered navigation. By default the flag it is active.
