### PR TITLE
Fix error on updating non dynamic propery

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Model/Resource/Engine/Elasticsearch/Index.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Resource/Engine/Elasticsearch/Index.php
@@ -477,7 +477,6 @@ class Smile_ElasticSearch_Model_Resource_Engine_Elasticsearch_Index
                     'body'  => array(
                         'number_of_replicas'        => (int) $this->getConfig('number_of_replicas'),
                         "refresh_interval"          => self::DIFF_REINDEX_REFRESH_INTERVAL,
-                        "merge.policy.merge_factor" => self::DIFF_REINDEX_MERGE_FACTOR,
                     )
                 )
             );


### PR DESCRIPTION
Hack around Can't update non dynamic settings[[index.merge.policy.merge_factor]] for open indices.

With version 2.2 and without this change, new index in elastic is created, but not given alias defined in magento.

Do not have too much idea about what I am doing, just reject this is change is stupid :)