### PR TITLE
FIX fallback to default Magento search if ES server is down (Issue #47)

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Block/Catalogsearch/Result.php
+++ b/src/app/code/community/Smile/ElasticSearch/Block/Catalogsearch/Result.php
@@ -28,7 +28,10 @@ class Smile_ElasticSearch_Block_Catalogsearch_Result extends Mage_CatalogSearch_
         if (!$this->getData('result_count')) {
             $productCollection = $this->_getProductCollection();
             $size = $productCollection->getSize();
-            if ($productCollection->isSpellchecked()) {
+            // In fallback case when ES server is down: in default result collection isSpellchecked() is not available
+            if (get_class($productCollection) == 'Smile_ElasticSearch_Model_Resource_Catalog_Product_Collection'
+                && $productCollection->isSpellchecked()
+            ) {
                 $this->_getQuery()->setNumResults(0);
             } else {
                 $this->_getQuery()->setNumResults($size);


### PR DESCRIPTION
Current implementation fails with an error if the Elasticsearch server is down, unavailable or catalog/search/engine configuration is set to "MySQL". 

`Call to undefined method Mage_Catalog_Model_Resource_Product_Collection::isSpellchecked()`

There was already an issue covering this problem: https://github.com/Smile-SA/smile-magento-elasticsearch/issues/47

Cause: In default Magento catalogsearch result collection isSpellchecked() is not available.
