### PR TITLE
Escape synonym special characters on export

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Model/Resource/CatalogSearch/Synonym/Collection.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Resource/CatalogSearch/Synonym/Collection.php
@@ -18,10 +18,20 @@
  */
 class Smile_ElasticSearch_Model_Resource_CatalogSearch_Synonym_Collection extends Mage_CatalogSearch_Model_Resource_Query_Collection
 {
+
+    /**
+     * @var string[]
+     */
+    protected $escapeMap = array(
+        ','  => '\\,',
+        '\\' => '\\\\',
+        '=>' => '\\=>',
+    );
+
     /**
      * Generates the synonym list for the search engine.
      *
-     * @return return array
+     * @return string[]
      */
     public function exportSynonymList()
     {
@@ -31,10 +41,21 @@ class Smile_ElasticSearch_Model_Resource_CatalogSearch_Synonym_Collection extend
         $adapter = $this->getConnection();
         $data = $adapter->fetchAll($this->getSelect());
         foreach ($data as $currentTerm) {
-            $currentTerm['synonym_for'] = sprintf('%s, %s', $currentTerm['query_text'], $currentTerm['synonym_for']);
-            $result[] = sprintf("%s => %s", $currentTerm['query_text'], $currentTerm['synonym_for']);
+            $synonymFor = $this->escapeSynonym($currentTerm['synonym_for']);
+            $queryText = $this->escapeSynonym($currentTerm['query_text']);
+            $result[] = "{$queryText} => {$queryText}, {$synonymFor}";
         }
 
         return $result;
+    }
+
+    /**
+     * @param string $str
+     *
+     * @return string
+     */
+    protected function escapeSynonym($str)
+    {
+        return strtr($str, $this->escapeMap);
     }
 }


### PR DESCRIPTION
Fix error [`IllegalArgumentException[term: was completely eliminated by analyzer]`](https://github.com/apache/lucene-solr/blob/99188ae00c0c46d9af47b9773d492de40de4aa83/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMap.java#L338)  caused by unescaped characters

I assume this to be the problem described in #59

Related file [TestSolrSynonymParser#testEscapedStuff()](https://github.com/apache/lucene-solr/blob/189e985b5c14c5c19799b7bdfd040874b94ba18c/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSolrSynonymParser.java#L131-L134)