### PR TITLE
Fix like and not like rules

### DIFF
--- a/src/app/code/community/Smile/VirtualCategories/Model/Rule/Condition/Product.php
+++ b/src/app/code/community/Smile/VirtualCategories/Model/Rule/Condition/Product.php
@@ -37,8 +37,8 @@ class Smile_VirtualCategories_Model_Rule_Condition_Product extends Mage_CatalogR
         '<='  => '#{field}:[* TO #{value}]',
         '>'   => '#{field}:{#{value} TO *]',
         '<'   => '#{field}:[* TO #{value}}',
-        '{}'  => '#{field}:#{value}*',
-        '!{}' => '#{field}:#{value}*'
+        '{}'  => '#{field}:*#{value}*',
+        '!{}' => '-(#{field}:*#{value}*)'
     );
 
     /**

--- a/src/app/code/community/Smile/VirtualCategories/Model/Rule/Condition/Product.php
+++ b/src/app/code/community/Smile/VirtualCategories/Model/Rule/Condition/Product.php
@@ -36,7 +36,7 @@ class Smile_VirtualCategories_Model_Rule_Condition_Product extends Mage_CatalogR
         '>='  => '#{field}:[#{value} TO *]',
         '<='  => '#{field}:[* TO #{value}]',
         '>'   => '#{field}:{#{value} TO *]',
-        '<'   => '#{field}:[* TO #{value}}',
+        '<'   => '#{field}:[* TO #{value}]',
         '{}'  => '#{field}:*#{value}*',
         '!{}' => '-(#{field}:*#{value}*)'
     );


### PR DESCRIPTION
Previouslylike rules only worked if the data field started with specified value, rather than contain it anywhere in its field. 

Is not like didn't work at all as it was identical to contain.