### PR TITLE
Error on category save after if engine is not active

### DIFF
--- a/src/app/code/community/Smile/ElasticSearch/Model/Observer.php
+++ b/src/app/code/community/Smile/ElasticSearch/Model/Observer.php
@@ -112,10 +112,12 @@ class Smile_ElasticSearch_Model_Observer
         $helper = Mage::helper('smile_elasticsearch');
         $category = $observer->getEvent()->getCategory();
         if ($helper->isEnterpriseSupportEnabled() == false) {
-            $productIds = $category->getProductCollection()->getAllIds();
-            $this->_getIndexer()->resetSearchResults();
-            $currentIndex = Mage::helper('catalogsearch')->getEngine()->getCurrentIndex();
-            $currentIndex->getMapping('product')->rebuildIndex(null, $productIds);
+            if ($helper->isActiveEngine()) {
+                $productIds = $category->getProductCollection()->getAllIds();
+                $this->_getIndexer()->resetSearchResults();
+                $currentIndex = Mage::helper('catalogsearch')->getEngine()->getCurrentIndex();
+                $currentIndex->getMapping('product')->rebuildIndex(null, $productIds);
+            }
         } else {
             $category = $observer->getEvent()->getCategory();
             $productIds = $category->getAffectedProductIds();


### PR DESCRIPTION
If module engine is not chosen in Catalog -> Catalog Search -> Search Engine

After saving catalog category you'll get an exception:
`Call to undefined method Mage_CatalogSearch_Model_Resource_Fulltext_Engine::getCurrentIndex()`

EcomDev_PHPUnit module tests are broken as well because they have default configuration and it breaks magento set up.