### PR TITLE
Bugfix for pages without smile tracker

### DIFF
--- a/src/app/code/community/Smile/Tracker/Block/Variables/Abstract.php
+++ b/src/app/code/community/Smile/Tracker/Block/Variables/Abstract.php
@@ -23,8 +23,7 @@ class Smile_Tracker_Block_Variables_Abstract extends Mage_Core_Block_Template
     public function isEnabled()
     {
         $mainBlock = $this->getLayout()->getBlock('smile.tracker.config');
-
-        return !is_null($mainBlock) && $mainBlock->isEnabled();
+        return $mainBlock && $mainBlock->isEnabled();
     }
 
     /**


### PR DESCRIPTION
Change implementation of block check because a non-existing block is "false" and not "null"